### PR TITLE
Support added for Rich Text Format RTF in Writer

### DIFF
--- a/multiFormatSave/chooseFormat.xdl
+++ b/multiFormatSave/chooseFormat.xdl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE dlg:window PUBLIC "-//OpenOffice.org//DTD OfficeDocument 1.0//EN" "dialog.dtd">
-<dlg:window xmlns:dlg="http://openoffice.org/2000/dialog" xmlns:script="http://openoffice.org/2000/script" dlg:id="chooseFormat" dlg:left="146" dlg:top="89" dlg:width="156" dlg:height="120" dlg:closeable="true" dlg:moveable="true" dlg:title="&amp;chooseDialog.Title">
+<dlg:window xmlns:dlg="http://openoffice.org/2000/dialog" xmlns:script="http://openoffice.org/2000/script" dlg:id="chooseFormat" dlg:left="146" dlg:top="83" dlg:width="156" dlg:height="136" dlg:closeable="true" dlg:moveable="true" dlg:title="&amp;chooseDialog.Title">
   <dlg:styles>
     <dlg:style dlg:style-id="0" dlg:text-color="0xff3333"/>
   </dlg:styles>
@@ -17,19 +17,22 @@
     <dlg:checkbox dlg:id="CB3" dlg:tab-index="5" dlg:left="12" dlg:top="72" dlg:width="120" dlg:height="8" dlg:checked="true">
       <script:event script:event-name="on-itemstatechange" script:macro-name="multiFormatSave.multiFormatSave.enableSaveButton" script:language="StarBasic"/>
     </dlg:checkbox>
-    <dlg:text dlg:id="LHelp" dlg:left="6" dlg:top="90" dlg:width="144" dlg:height="10" dlg:multiline="true" dlg:style-id="0"/>
-    <dlg:button dlg:id="BSave" dlg:tab-index="6" dlg:left="72" dlg:top="100" dlg:width="35" dlg:height="13" dlg:value="&amp;chooseDialog.BSave.value" enabled="false">
+    <dlg:checkbox dlg:id="CB4" dlg:tab-index="6" dlg:left="12" dlg:top="82" dlg:width="120" dlg:height="8" dlg:checked="true">
+      <script:event script:event-name="on-itemstatechange" script:macro-name="multiFormatSave.multiFormatSave.enableSaveButton" script:language="StarBasic"/>
+    </dlg:checkbox>
+    <dlg:text dlg:id="LHelp" dlg:left="6" dlg:top="100" dlg:width="144" dlg:height="10" dlg:multiline="true" dlg:style-id="0"/>
+    <dlg:button dlg:id="BSave" dlg:tab-index="7" dlg:left="72" dlg:top="110" dlg:width="35" dlg:height="13" dlg:value="&amp;chooseDialog.BSave.value" enabled="false">
        <script:event script:event-name="on-performaction" script:macro-name="multiFormatSave.multiFormatSave.saveButtonPressed" script:language="StarBasic"/>
     </dlg:button>
-    <dlg:button dlg:id="BCancel" dlg:tab-index="7" dlg:left="115" dlg:top="100" dlg:width="35" dlg:height="13" dlg:button-type="cancel" dlg:value="&amp;chooseDialog.BCancel.value"/>
-    <dlg:text dlg:id="LPath" dlg:tab-index="8" dlg:left="6" dlg:top="6" dlg:width="69" dlg:height="9" dlg:value="&amp;chooseDialog.LPath.value"/>
+    <dlg:button dlg:id="BCancel" dlg:tab-index="8" dlg:left="115" dlg:top="110" dlg:width="35" dlg:height="13" dlg:button-type="cancel" dlg:value="&amp;chooseDialog.BCancel.value"/>
+    <dlg:text dlg:id="LPath" dlg:tab-index="9" dlg:left="6" dlg:top="6" dlg:width="69" dlg:height="9" dlg:value="&amp;chooseDialog.LPath.value"/>
     <dlg:textfield dlg:id="TFPath" dlg:tab-index="0" dlg:left="6" dlg:top="17" dlg:width="125" dlg:height="13">
       <script:event script:event-name="on-textchange" script:macro-name="multiFormatSave.multiFormatSave.enableSaveButton" script:language="StarBasic"/>
     </dlg:textfield>
     <dlg:button dlg:id="BPath" dlg:tab-index="1" dlg:left="137" dlg:top="16" dlg:width="13" dlg:height="15" dlg:value="...">
       <script:event script:event-name="on-performaction" script:macro-name="multiFormatSave.multiFormatSave.choosePath" script:language="StarBasic"/>
     </dlg:button>
-    <dlg:titledbox dlg:id="FCFileFormat" dlg:left="6" dlg:top="33" dlg:width="144" dlg:height="54">
+    <dlg:titledbox dlg:id="FCFileFormat" dlg:left="6" dlg:top="33" dlg:width="144" dlg:height="64">
       <dlg:title dlg:value="&amp;chooseDialog.FCFileFormat.Title"/>
     </dlg:titledbox>
   </dlg:bulletinboard>

--- a/multiFormatSave/chooseFormatOpenOffice.xdl
+++ b/multiFormatSave/chooseFormatOpenOffice.xdl
@@ -17,12 +17,15 @@
     <dlg:checkbox dlg:id="CB3" dlg:tab-index="5" dlg:left="12" dlg:top="62" dlg:width="120" dlg:height="8" dlg:checked="true">
       <script:event script:event-name="on-itemstatechange" script:macro-name="multiFormatSave.multiFormatSave.enableSaveButton" script:language="StarBasic"/>
     </dlg:checkbox>
+    <dlg:checkbox dlg:id="CB4" dlg:tab-index="6" dlg:left="12" dlg:top="62" dlg:width="120" dlg:height="8" dlg:checked="false" dlg:visible="false">
+      <script:event script:event-name="on-itemstatechange" script:macro-name="multiFormatSave.multiFormatSave.enableSaveButton" script:language="StarBasic"/>
+    </dlg:checkbox>
     <dlg:text dlg:id="LHelp" dlg:left="6" dlg:top="80" dlg:width="144" dlg:height="10" dlg:multiline="true" dlg:style-id="0"/>
-    <dlg:button dlg:id="BSave" dlg:tab-index="6" dlg:left="72" dlg:top="90" dlg:width="35" dlg:height="13" dlg:value="&amp;chooseDialog.BSave.value" enabled="false">
+    <dlg:button dlg:id="BSave" dlg:tab-index="7" dlg:left="72" dlg:top="90" dlg:width="35" dlg:height="13" dlg:value="&amp;chooseDialog.BSave.value" enabled="false">
        <script:event script:event-name="on-performaction" script:macro-name="multiFormatSave.multiFormatSave.saveButtonPressed" script:language="StarBasic"/>
     </dlg:button>
-    <dlg:button dlg:id="BCancel" dlg:tab-index="7" dlg:left="115" dlg:top="90" dlg:width="35" dlg:height="13" dlg:button-type="cancel" dlg:value="&amp;chooseDialog.BCancel.value"/>
-    <dlg:text dlg:id="LPath" dlg:tab-index="8" dlg:left="6" dlg:top="6" dlg:width="69" dlg:height="9" dlg:value="&amp;chooseDialog.LPath.value"/>
+    <dlg:button dlg:id="BCancel" dlg:tab-index="8" dlg:left="115" dlg:top="90" dlg:width="35" dlg:height="13" dlg:button-type="cancel" dlg:value="&amp;chooseDialog.BCancel.value"/>
+    <dlg:text dlg:id="LPath" dlg:tab-index="9" dlg:left="6" dlg:top="6" dlg:width="69" dlg:height="9" dlg:value="&amp;chooseDialog.LPath.value"/>
     <dlg:textfield dlg:id="TFPath" dlg:tab-index="0" dlg:left="6" dlg:top="17" dlg:width="125" dlg:height="13">
       <script:event script:event-name="on-textchange" script:macro-name="multiFormatSave.multiFormatSave.enableSaveButton" script:language="StarBasic"/>
     </dlg:textfield>

--- a/multiFormatSave/multiFormatSave.xba
+++ b/multiFormatSave/multiFormatSave.xba
@@ -28,13 +28,14 @@ Global sCurrentURL As String
 Global sSaveURL As String
 
 ' Decleration of constants
-CONST DIFFERENT_FORMATS = 4
+CONST DIFFERENT_FORMATS = 5
 CONST ODF = 0
 CONST MSO = 1
 CONST PNG = 1
 CONST MSX = 2
 CONST SVG = 2
 CONST PDF = 3
+CONST RTF = 4
 CONST EXTENSION_NAME = "multiFormatSave"
 
 CONST DOC_WRITER = "com.sun.star.text.TextDocument"
@@ -160,6 +161,7 @@ Function getFileDescriptors( sURL As String, aFormats() As Integer ) As Array
     createFileDescriptor( aFileDescriptorList( iCounter ), aFormats( MSO ), iCounter, MSO, sURL + ".doc", "MS Word 97"  )
     createFileDescriptor( aFileDescriptorList( iCounter ), aFormats( MSX ), iCounter, MSX, sURL + ".docx", "MS Word 2007 XML" )
     createFileDescriptor( aFileDescriptorList( iCounter ), aFormats( PDF ), iCounter, PDF, sURL + ".pdf", "writer_pdf_Export" )
+    createFileDescriptor( aFileDescriptorList( iCounter ), aFormats( RTF ), iCounter, RTF, sURL + ".rtf", "Rich Text Format" )
   ElseIf ThisComponent.SupportsService( DOC_CALC ) Then
     createFileDescriptor( aFileDescriptorList( iCounter ), aFormats( ODF ), iCounter, ODF, sURL + ".ods" )
     createFileDescriptor( aFileDescriptorList( iCounter ), aFormats( MSO ), iCounter, MSO, sURL + ".xls", "MS Excel 97"  )
@@ -286,6 +288,9 @@ Function getFormatSettings() As Array
 
   oConfigAccess = getConfigAccess( "/multiFormatSave.multiFormatSave/multiFormatSaveConfig/settings/formats" )
   aFormats( ODF ) = oConfigAccess.ODF
+  If ThisComponent.SupportsService( DOC_WRITER ) Then 
+    aFormats( RTF ) = oConfigAccess.RTF
+  EndIf 
   If ThisComponent.SupportsService( DOC_DRAW ) Then 
     aFormats( PNG ) = oConfigAccess.PNG
     aFormats( SVG ) = oConfigAccess.SVG
@@ -319,6 +324,9 @@ Function setFormatSettings( aFormats() As Integer )
 
   oConfigAccess = getConfigAccess( "/multiFormatSave.multiFormatSave/multiFormatSaveConfig/settings/formats" )
   oConfigAccess.ODF = aFormats( ODF )
+  If ThisComponent.SupportsService( DOC_WRITER ) Then 
+    oConfigAccess.RTF = aFormats( RTF )
+  EndIf 
   If ThisComponent.SupportsService( DOC_DRAW ) Then 
     oConfigAccess.PNG = aFormats( PNG )
     oConfigAccess.SVG = aFormats( SVG )
@@ -334,11 +342,16 @@ End Function ' setFormatSettings
 
 ' Sets initialization of the UI
 Function initUI()
+  Dim oCB4 As Object
+  oCB4 = dChooseFormat.getControl("CB4")
+  oCB4.Visible = False
   If ThisComponent.SupportsService( DOC_WRITER ) Then
     dChooseFormat.model.CB0.Label = GetFilterName("writer8") + " (odt)"
     dChooseFormat.model.CB1.Label = GetFilterName("MS Word 97") + " (doc)"
     dChooseFormat.model.CB2.Label = GetFilterName("MS Word 2007 XML") + " (docx)"
     dChooseFormat.model.CB3.Label = GetFilterName("writer_pdf_Export") + " (pdf)"
+    oCB4.Visible = True
+    dChooseFormat.model.CB4.Label = GetFilterName("Rich Text Format") + " (rtf)"
   ElseIf ThisComponent.SupportsService( DOC_CALC ) Then
     dChooseFormat.model.CB0.Label = GetFilterName("calc8") + " (ods)"
     dChooseFormat.model.CB1.Label = GetFilterName("MS Excel 97") + " (xls)"
@@ -366,6 +379,7 @@ Function getUIProperties( sURL As String, aFormats() as Integer )
   aFormats( 1 ) = dChooseFormat.model.CB1.state
   aFormats( 2 ) = dChooseFormat.model.CB2.state
   aFormats( 3 ) = dChooseFormat.model.CB3.state
+  aFormats( 4 ) = dChooseFormat.model.CB4.state
 End Function ' getUIProperties
 
 ' Get the values from the interface's widgets.
@@ -376,12 +390,13 @@ Function setUIProperties( sURL As String, aFormats() as Integer )
   dChooseFormat.model.CB1.state = aFormats( 1 )
   dChooseFormat.model.CB2.state = aFormats( 2 )
   dChooseFormat.model.CB3.state = aFormats( 3 )
+  dChooseFormat.model.CB4.state = aFormats( 4 )
 End Function ' setUIProperties
 
 ' Check if the save-button needs to be enabled
 ' Function called when one of the textFields or checkBoxes are changed.
 Function enableSaveButton()
-If ( DChooseFormat.model.CB0.state = 0 And DChooseFormat.model.CB1.state = 0 And DChooseFormat.model.CB2.state = 0 And DChooseFormat.model.CB3.state = 0 ) Then
+If ( DChooseFormat.model.CB0.state = 0 And DChooseFormat.model.CB1.state = 0 And DChooseFormat.model.CB2.state = 0 And DChooseFormat.model.CB3.state = 0 And DChooseFormat.model.CB4.state = 0 ) Then
     DChooseFormat.model.BSave.enabled = FALSE
     DChooseFormat.model.LHelp.Label = "&amp;InputFormatError"
   ElseIf ( DChooseFormat.model.TFPath.text = "" Or right( DChooseFormat.model.TFPath.text, 1) = "/") Then

--- a/multiFormatSave/multiFormatSave.xcs
+++ b/multiFormatSave/multiFormatSave.xcs
@@ -8,6 +8,7 @@
       <prop oor:name="PDF" oor:type="xs:int"/>
       <prop oor:name="SVG" oor:type="xs:int"/>
       <prop oor:name="PNG" oor:type="xs:int"/>
+      <prop oor:name="RTF" oor:type="xs:int"/>
     </group>
   </templates>
   <component>

--- a/multiFormatSave/multiFormatSave.xcu
+++ b/multiFormatSave/multiFormatSave.xcu
@@ -21,6 +21,9 @@
 	<prop oor:name="PNG" oor:type="xs:int">
 	  <value>1</value>
 	</prop>
+	<prop oor:name="RTF" oor:type="xs:int">
+	  <value>0</value>
+	</prop>
 
       </node>
     </node>


### PR DESCRIPTION
Added support for multi-saving to RTF format in LibreOffice Writer, with corresponding checkbox added to dialog box (which only appears when multi-saving in Writer).  Tested with LibreOffice 5.1.4.2 on Mac OS X.

Support for OpenOffice Writer not added as I don't have OpenOffice to test with, but a corresponding checkbox was added and made invisible (same solution as in the style of the MS Office XML checkbox which is also invisible in OpenOffice).

RTF format was wanted as it is a common interoperable human-readable word document format to multi-save to for archival purpose.
